### PR TITLE
Fix for incorrect image sizes in edit mode on image component Banner Variant

### DIFF
--- a/headapps/aspnet-core-starter/Views/Shared/Components/SitecoreComponent/Image.cshtml
+++ b/headapps/aspnet-core-starter/Views/Shared/Components/SitecoreComponent/Image.cshtml
@@ -1,37 +1,41 @@
 ﻿@model Sitecore.AspNetCore.Starter.Models.Image
 
+@{
+    bool isEditing = Model?.IsEditing ?? false;
+}
+
 @if (Model.FieldNames == Image.VARIANT_BANNER)
 {
-    bool isEditing = Model?.IsEditing ?? false;
+    
     string classHeroBannerEmpty = !isEditing && string.IsNullOrWhiteSpace(Model.ImageField?.Value.Src) ? "hero-banner-empty" : string.Empty;
     string backgroundStyle = !string.IsNullOrWhiteSpace(Model?.ImageField?.Value.Src) && !isEditing ? $"background-image: url('{@Model.ImageField?.Value.Src}')" : string.Empty;
 
-        <div class="component hero-banner @Model?.Styles @Model?.GridParameters @classHeroBannerEmpty" id="@Model?.Id">
-            <div class="component-content sc-sxa-image-hero-banner" style="@backgroundStyle">
+    <div class="component hero-banner @Model?.Styles @Model?.GridParameters @classHeroBannerEmpty" id="@Model?.Id">
+        <div class="component-content sc-sxa-image-hero-banner" style="@backgroundStyle">
             @if (isEditing)
             {
                 <div class="image">
                     <sc-img asp-for="@Model.ImageField" />
                 </div>
             }
-            </div>
         </div>
+    </div>
 }
 else
 {
     <div class="component image @Model.Styles @Model.GridParameters" id="@Model.Id">
         <div class="component-content">
             <span class="sc-image-wrapper">
-            @if (Model?.IsEditing ?? false || string.IsNullOrWhiteSpace(Model.TargetUrl?.Value.Href))
-            {
-                <sc-img asp-for="@Model.ImageField" />
-            }
-            else
-            {
-                <sc-link asp-for="@Model.TargetUrl">
+                @if (isEditing || string.IsNullOrWhiteSpace(Model.TargetUrl?.Value.Href))
+                {
                     <sc-img asp-for="@Model.ImageField" />
-                </sc-link>
-            }
+                }
+                else
+                {
+                    <sc-link asp-for="@Model.TargetUrl">
+                        <sc-img asp-for="@Model.ImageField" />
+                    </sc-link>
+                }
             </span>
             <span class="image-caption field-imagecaption">
                 <span asp-for="@Model.ImageCaption"></span>

--- a/headapps/aspnet-core-starter/Views/Shared/Components/SitecoreComponent/Image.cshtml
+++ b/headapps/aspnet-core-starter/Views/Shared/Components/SitecoreComponent/Image.cshtml
@@ -1,34 +1,37 @@
 ﻿@model Sitecore.AspNetCore.Starter.Models.Image
 
-@if(Model.FieldNames == Image.VARIANT_BANNER)
+@if (Model.FieldNames == Image.VARIANT_BANNER)
 {
-    string classHeroBannerEmpty = Model.IsEditing && string.IsNullOrWhiteSpace(Model.ImageField?.Value.Src) ? "hero-banner-empty" : string.Empty;
-    string backgroundStyle = !string.IsNullOrWhiteSpace(Model?.ImageField?.Value.Src) ? $"background-image: url('{@Model.ImageField?.Value.Src}')" : string.Empty;
+    bool isEditing = Model?.IsEditing ?? false;
+    string classHeroBannerEmpty = !isEditing && string.IsNullOrWhiteSpace(Model.ImageField?.Value.Src) ? "hero-banner-empty" : string.Empty;
+    string backgroundStyle = !string.IsNullOrWhiteSpace(Model?.ImageField?.Value.Src) && !isEditing ? $"background-image: url('{@Model.ImageField?.Value.Src}')" : string.Empty;
 
-    <div class="component hero-banner @Model?.Styles @Model?.GridParameters @classHeroBannerEmpty" id="@Model?.Id">
-        <div class="component-content sc-sxa-image-hero-banner" style="@backgroundStyle">
-            @if (Model?.IsEditing ?? false)
+        <div class="component hero-banner @Model?.Styles @Model?.GridParameters @classHeroBannerEmpty" id="@Model?.Id">
+            <div class="component-content sc-sxa-image-hero-banner" style="@backgroundStyle">
+            @if (isEditing)
             {
-                <sc-img asp-for="@Model.ImageField" />
+                <div class="image">
+                    <sc-img asp-for="@Model.ImageField" />
+                </div>
             }
+            </div>
         </div>
-    </div>
 }
 else
 {
     <div class="component image @Model.Styles @Model.GridParameters" id="@Model.Id">
         <div class="component-content">
             <span class="sc-image-wrapper">
-                @if (Model.IsEditing || string.IsNullOrWhiteSpace(Model.TargetUrl?.Value.Href))
-                {
+            @if (Model?.IsEditing ?? false || string.IsNullOrWhiteSpace(Model.TargetUrl?.Value.Href))
+            {
+                <sc-img asp-for="@Model.ImageField" />
+            }
+            else
+            {
+                <sc-link asp-for="@Model.TargetUrl">
                     <sc-img asp-for="@Model.ImageField" />
-                }
-                else
-                {
-                    <sc-link asp-for="@Model.TargetUrl">
-                        <sc-img asp-for="@Model.ImageField" />
-                    </sc-link>
-                }
+                </sc-link>
+            }
             </span>
             <span class="image-caption field-imagecaption">
                 <span asp-for="@Model.ImageCaption"></span>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
The current behavior of image component Banner variant in edit mode is, that the image is rendered full size, which leads to massive overlap with other components on the page. This only happens in Edit mode.
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
1. I added a proper div container arround the image field to let it participate in the following rule set in CSS
```
.image img {
  max-width: 100%;
  height: auto;
}
```
2. I added a conditional rendering of the background image to avoid double rendering the background one AND the one from sc-img tag helper

<!-- Why is this change required? What problem does it solve? -->
This solves the following:
1. The image is not rendered full size in editing anymore
2. There is no double rendering of background image and sc-img anymore in editing

Behavior with applied fix:
![image](https://github.com/user-attachments/assets/e824bbbf-72e8-44cb-be77-261ab18a8581)

<!-- If it fixes an open issue, please link to the issue here. -->
This PR fixes the following reported Bug: Closes https://github.com/Sitecore/xmcloud-starter-dotnet/issues/10


## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [ x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
