### PR TITLE
Fixed issue with local docker after contextId changes

### DIFF
--- a/headapps/aspnet-core-starter/Models/SitecoreSettings.cs
+++ b/headapps/aspnet-core-starter/Models/SitecoreSettings.cs
@@ -13,4 +13,8 @@ public class SitecoreSettings
     public bool EnableEditingMode { get; set; }
 
     public string? EditingPath { get; set; }
+
+    public bool EnableLocalContainer { get; set; }
+
+    public Uri? LocalContainerLayoutUri { get; set; }
 }

--- a/headapps/aspnet-core-starter/Program.cs
+++ b/headapps/aspnet-core-starter/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Configuration;
 using Sitecore.AspNetCore.SDK.GraphQL.Extensions;
 using Sitecore.AspNetCore.Starter.Extensions;
 using System.Globalization;
@@ -18,9 +19,20 @@ builder.Services.AddGraphQlClient(configuration =>
                 })
                 .AddMultisite(); 
 
-builder.Services.AddSitecoreLayoutService()
-                .AddGraphQlWithContextHandler("default", sitecoreSettings.EdgeContextId!, siteName: sitecoreSettings.DefaultSiteName!)
-                .AsDefaultHandler();
+if (sitecoreSettings.EnableLocalContainer)
+{
+    // Register the GraphQL version of the Sitecore Layout Service Client for use against local container endpoint
+    builder.Services.AddSitecoreLayoutService()
+                    .AddGraphQlHandler("default", sitecoreSettings.DefaultSiteName!, sitecoreSettings.EdgeContextId!, sitecoreSettings.LocalContainerLayoutUri!)
+                    .AsDefaultHandler();
+}
+else
+{
+    // Register the GraphQL version of the Sitecore Layout Service Client for use against experience edge
+    builder.Services.AddSitecoreLayoutService()
+                    .AddGraphQlWithContextHandler("default", sitecoreSettings.EdgeContextId!, siteName: sitecoreSettings.DefaultSiteName!)
+                    .AsDefaultHandler();
+}
 
 builder.Services.AddSitecoreRenderingEngine(options =>
                     {

--- a/local-containers/docker-compose.override.yml
+++ b/local-containers/docker-compose.override.yml
@@ -37,10 +37,10 @@ services:
       DOTNET_WATCH_RESTART_ON_RUDE_EDIT: true
       DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER: true
       MVP_RENDERING_EDITING_HOST_URI: "http://aspnet-core-starter"
-      Sitecore__InstanceUri: "http://cm"
-      Sitecore__LayoutServicePath: "/sitecore/api/graph/edge/"
       Sitecore__EnableEditingMode: "true" 
-      Sitecore__ExperienceEdgeToken: ${SITECORE_API_KEY_ASPNETCORE_STARTER}
+      Sitecore__EnableLocalContainer: "true"
+      Sitecore__LocalContainerLayoutUri: "http://cm/sitecore/api/graph/edge"
+      Sitecore__EdgeContextId: ${SITECORE_API_KEY_ASPNETCORE_STARTER}
       Sitecore__EditingSecret: ${EDITING_SECRET}
       Sitecore__DefaultSiteName: ${SITE_NAME}
     ports:


### PR DESCRIPTION
The recent changes to move to leverage the ContectID connection approach had broken the local containers developer experience.

This fixes it.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).

Closes #16 
