### PR TITLE
Improved Font loading

### DIFF
--- a/headapps/aspnet-core-starter/Views/Shared/_Layout.cshtml
+++ b/headapps/aspnet-core-starter/Views/Shared/_Layout.cshtml
@@ -8,6 +8,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <link rel="stylesheet" href="/styles/bootstrap-5.1.3.min.css">
     <link rel="stylesheet" href="/styles/skatepark.min.css" />
+    <link rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"
+          media="print"
+          onload="this.media='all'" />
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+          media="print"
+          onload="this.media='all'" />
+    <link rel="stylesheet"
+          href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"
+          media="print"
+          onload="this.media='all'" />
 </head>
 
 <body>

--- a/headapps/aspnet-core-starter/wwwroot/styles/skatepark.css
+++ b/headapps/aspnet-core-starter/wwwroot/styles/skatepark.css
@@ -1,8 +1,5 @@
 ﻿@charset "UTF-8";
-@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap");
-/* FontAwesome */
-@import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"); /* breakpoints */
-@import url("https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese");
+    
 body {
   font-family: Roboto;
   color: #27272A;


### PR DESCRIPTION
Currently fonts are loaded in a way, that it blocks the first paint of the website. This drains the lighthouse score a bit. To avoid that, the font loading was changed

<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
Font loading is removed from the CSS and put into the .cshtml file as link reference. That way fonts are now loading non-blocking in the background
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/Sitecore/xmcloud-starter-dotnet/issues/18

After applying the changes, fonts are still loaded correctly and lighthouse does not complain anymore about render blocking resources (fonts)
![image](https://github.com/user-attachments/assets/3341545d-47d1-43e3-842a-0a38a943fd66)


## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
