### PR TITLE
Pages MetaData Editing Mode Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,11 @@ This Github repository is a template that can be used to create your own reposit
 
 ### Connecting Pages to your locally running application
 
-1. Open `./headapps/aspnet-core-starter.sln` in Visual Studio then Create a local dev tunnel by following this [guide](https://learn.microsoft.com/en-us/connectors/custom-connectors/port-tunneling)
+1. Open `./headapps/aspnet-core-starter.sln` in Visual Studio.
 2. Hit F5 to run the application from Visual Studio.
-3. When the page loads make a note of the URL, it should in the format `https://localhost:<port>`. If successful you should see a plain white page rendered.
+3. When the page loads, make a note of the URL. It should be in the format `https://localhost:<port>`. If successful, you should see a plain white page rendered.
 4. In the Pages Editor, select `Localhost` for your editing host, and paste your localhost URL, including the port number.
-5. Alternatively, you can choose to run your visual studio application with [Dev Tunnels enabled](https://learn.microsoft.com/en-us/aspnet/core/test/dev-tunnels?view=aspnetcore-9.0). Please note the dev tunnel URL after pressing F5. It should in the format: `https://XXXX.devtunnels.ms/`.
-    - Return to the Content Editor
-    - Navigate to the `/sitecore/system/Settings/Services/Rendering Hosts/Default` item, and set the following values, ensuring you save the changes:
-        - `Server side rendering engine endpoint URL` - `https://<<TUNNEL_URL>>/jss-render`
-        - `Server side rendering engine application URL` - `https://<<TUNNEL_URL>>`
-        - `Server side rendering engine configuration URL` - `https://<<TUNNEL_URL>>/api/editing/config`
-    - Click the Home icon in the top left corner of the Content Editor (the nine square grid icon).
-    - Click on the Pages icon
-    - You will be taken to your Pages instance, which is now connected to the head application running on your local devleoper machine. You can now add and remove components from the page and see the changes reflected in real-time. Please note the known issues stated above to see which components are not yet supported.
+5. Pages is now connected to the head application running on your local devleoper machine. You can now add and remove components from the page and see the changes reflected in real-time. Please note the known issues stated above to see which components are not yet supported.
 
 ## Disconnected offline development
 It is possible to mock a small subset of the XM Cloud Application elements to enable offline development. This can allow for a disconnected development experience, however it is recommend to work in the default connected mode.

--- a/README.md
+++ b/README.md
@@ -47,20 +47,20 @@ This Github repository is a template that can be used to create your own reposit
 16. You will now be able to access the application at `https://localhost:5001/`.
 
 ### Connecting Pages to your locally running application
-> [!NOTE]
-> Temporary steps to connect Pages to your locally running application. This will be updated Meta Page Editing mode is supported.
 
 1. Open `./headapps/aspnet-core-starter.sln` in Visual Studio then Create a local dev tunnel by following this [guide](https://learn.microsoft.com/en-us/connectors/custom-connectors/port-tunneling)
-2. Hit F5 to run the application from Visual Studio, ensuring you have enabled your dev tunnel.
-3. When the page loads make a note of the URL, it should in the format `https://XXXX.devtunnels.ms/`. If successful you should see a plan white page rendered.
-4. Return to the Content Editor
-5. Navigate to the `/sitecore/system/Settings/Services/Rendering Hosts/Default` item, and set the following values, ensuring you save the changes:
-    - `Server side rendering engine endpoint URL` - `https://<<TUNNEL_URL>>/jss-render`
-    - `Server side rendering engine application URL` - `https://<<TUNNEL_URL>>`
-    - `Server side rendering engine configuration URL` - `https://<<TUNNEL_URL>>/api/editing/config`
-6. Click the Home icon in the top left corner of the Content Editor (the nine square grid icon).
-7. Click on the Pages icon
-8. You will be taken to your Pages instance, which is now connected to the head application running on your local devleoper machine. You can now add and remove components from the page and see the changes reflected in real-time. Please note the known issues stated above to see which components are not yet supported.
+2. Hit F5 to run the application from Visual Studio.
+3. When the page loads make a note of the URL, it should in the format `https://localhost:<port>`. If successful you should see a plain white page rendered.
+4. In the Pages Editor, select `Localhost` for your editing host, and paste your localhost URL, including the port number.
+5. Alternatively, you can choose to run your visual studio application with [Dev Tunnels enabled](https://learn.microsoft.com/en-us/aspnet/core/test/dev-tunnels?view=aspnetcore-9.0). Please note the dev tunnel URL after pressing F5. It should in the format: `https://XXXX.devtunnels.ms/`.
+    - Return to the Content Editor
+    - Navigate to the `/sitecore/system/Settings/Services/Rendering Hosts/Default` item, and set the following values, ensuring you save the changes:
+        - `Server side rendering engine endpoint URL` - `https://<<TUNNEL_URL>>/jss-render`
+        - `Server side rendering engine application URL` - `https://<<TUNNEL_URL>>`
+        - `Server side rendering engine configuration URL` - `https://<<TUNNEL_URL>>/api/editing/config`
+    - Click the Home icon in the top left corner of the Content Editor (the nine square grid icon).
+    - Click on the Pages icon
+    - You will be taken to your Pages instance, which is now connected to the head application running on your local devleoper machine. You can now add and remove components from the page and see the changes reflected in real-time. Please note the known issues stated above to see which components are not yet supported.
 
 ## Disconnected offline development
 It is possible to mock a small subset of the XM Cloud Application elements to enable offline development. This can allow for a disconnected development experience, however it is recommend to work in the default connected mode.

--- a/headapps/Directory.Packages.props
+++ b/headapps/Directory.Packages.props
@@ -1,13 +1,15 @@
 <Project>
-    <PropertyGroup>
-        <AspNetCoreSdkVersion>0.0.11</AspNetCoreSdkVersion>
-    </PropertyGroup>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include="Sitecore.AspNetCore.SDK.LayoutService.Client" Version="$(AspNetCoreSdkVersion)" />
-        <PackageVersion Include="Sitecore.AspNetCore.SDK.RenderingEngine" Version="$(AspNetCoreSdkVersion)" />
-        <PackageVersion Include="Sitecore.AspNetCore.SDK.ExperienceEditor" Version="$(AspNetCoreSdkVersion)" />
-    </ItemGroup>
+  <PropertyGroup>
+    <AspNetCoreSdkVersion>0.0.14</AspNetCoreSdkVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Sitecore.AspNetCore.SDK.GraphQL" Version="$(AspNetCoreSdkVersion)" />
+    <PackageVersion Include="Sitecore.AspNetCore.SDK.LayoutService.Client" Version="$(AspNetCoreSdkVersion)" />
+    <PackageVersion Include="Sitecore.AspNetCore.SDK.Pages" Version="$(AspNetCoreSdkVersion)" />
+    <PackageVersion Include="Sitecore.AspNetCore.SDK.RenderingEngine" Version="$(AspNetCoreSdkVersion)" />
+    <PackageVersion Include="Sitecore.AspNetCore.SDK.ExperienceEditor" Version="$(AspNetCoreSdkVersion)" />
+  </ItemGroup>
 </Project>

--- a/headapps/aspnet-core-starter/Program.cs
+++ b/headapps/aspnet-core-starter/Program.cs
@@ -16,7 +16,7 @@ builder.Services.AddRouting()
                 .AddLocalization()
                 .AddMvc();
 
-builder.Services.AddGraphQlClient(configuration =>
+builder.Services.AddGraphQLClient(configuration =>
                 {
                     configuration.ContextId = sitecoreSettings.EdgeContextId;
                 })
@@ -27,7 +27,7 @@ if (sitecoreSettings.EnableLocalContainer)
     // Register the GraphQL version of the Sitecore Layout Service Client for use against local container endpoint
     builder.Services.AddSitecoreLayoutService()
                     .AddSitecorePagesHandler()
-                    .AddGraphQlHandler("default", sitecoreSettings.DefaultSiteName!, sitecoreSettings.EdgeContextId!, sitecoreSettings.LocalContainerLayoutUri!)
+                    .AddGraphQLHandler("default", sitecoreSettings.DefaultSiteName!, sitecoreSettings.EdgeContextId!, sitecoreSettings.LocalContainerLayoutUri!)
                     .AsDefaultHandler();
 }
 else
@@ -35,7 +35,7 @@ else
     // Register the GraphQL version of the Sitecore Layout Service Client for use against experience edge
     builder.Services.AddSitecoreLayoutService()
                     .AddSitecorePagesHandler()
-                    .AddGraphQlWithContextHandler("default", sitecoreSettings.EdgeContextId!, siteName: sitecoreSettings.DefaultSiteName!)
+                    .AddGraphQLWithContextHandler("default", sitecoreSettings.EdgeContextId!, siteName: sitecoreSettings.DefaultSiteName!)
                     .AsDefaultHandler();
 }
 

--- a/headapps/aspnet-core-starter/Program.cs
+++ b/headapps/aspnet-core-starter/Program.cs
@@ -1,12 +1,15 @@
 using Microsoft.AspNetCore.Localization;
-using Microsoft.Extensions.Configuration;
 using Sitecore.AspNetCore.SDK.GraphQL.Extensions;
+using Sitecore.AspNetCore.SDK.Pages.Configuration;
+using Sitecore.AspNetCore.SDK.Pages.Extensions;
 using Sitecore.AspNetCore.Starter.Extensions;
 using System.Globalization;
+
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 SitecoreSettings? sitecoreSettings = builder.Configuration.GetSection(SitecoreSettings.Key).Get<SitecoreSettings>();
+PagesOptions? pagesSettings = builder.Configuration.GetSection(PagesOptions.Key).Get<PagesOptions>() ?? new PagesOptions();
 ArgumentNullException.ThrowIfNull(sitecoreSettings);
 
 builder.Services.AddRouting()
@@ -17,12 +20,13 @@ builder.Services.AddGraphQlClient(configuration =>
                 {
                     configuration.ContextId = sitecoreSettings.EdgeContextId;
                 })
-                .AddMultisite(); 
+                .AddMultisite();
 
 if (sitecoreSettings.EnableLocalContainer)
 {
     // Register the GraphQL version of the Sitecore Layout Service Client for use against local container endpoint
     builder.Services.AddSitecoreLayoutService()
+                    .AddSitecorePagesHandler()
                     .AddGraphQlHandler("default", sitecoreSettings.DefaultSiteName!, sitecoreSettings.EdgeContextId!, sitecoreSettings.LocalContainerLayoutUri!)
                     .AsDefaultHandler();
 }
@@ -30,6 +34,7 @@ else
 {
     // Register the GraphQL version of the Sitecore Layout Service Client for use against experience edge
     builder.Services.AddSitecoreLayoutService()
+                    .AddSitecorePagesHandler()
                     .AddGraphQlWithContextHandler("default", sitecoreSettings.EdgeContextId!, siteName: sitecoreSettings.DefaultSiteName!)
                     .AsDefaultHandler();
 }
@@ -40,7 +45,7 @@ builder.Services.AddSitecoreRenderingEngine(options =>
                                .AddDefaultPartialView("_ComponentNotFound");
                     })
                 .ForwardHeaders()
-                .WithExperienceEditor(options => { options.JssEditingSecret = sitecoreSettings.EditingSecret ?? string.Empty; });
+                .WithSitecorePages(sitecoreSettings.EdgeContextId ?? string.Empty, options => { options.EditingSecret = sitecoreSettings.EditingSecret; });
 
 WebApplication app = builder.Build();
 
@@ -56,7 +61,7 @@ else
 
 if (sitecoreSettings.EnableEditingMode)
 {
-    app.UseSitecoreExperienceEditor();
+    app.UseSitecorePages(pagesSettings);
 }
 
 app.UseRouting();

--- a/headapps/aspnet-core-starter/Views/Shared/_Layout.cshtml
+++ b/headapps/aspnet-core-starter/Views/Shared/_Layout.cshtml
@@ -20,6 +20,7 @@
           href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"
           media="print"
           onload="this.media='all'" />
+    <sc-editingscripts></sc-editingscripts>
 </head>
 
 <body>

--- a/headapps/aspnet-core-starter/Views/_ViewImports.cshtml
+++ b/headapps/aspnet-core-starter/Views/_ViewImports.cshtml
@@ -1,2 +1,3 @@
 ﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, Sitecore.AspNetCore.SDK.RenderingEngine
+@addTagHelper *, Sitecore.AspNetCore.SDK.Pages

--- a/headapps/aspnet-core-starter/aspnet-core-starter.csproj
+++ b/headapps/aspnet-core-starter/aspnet-core-starter.csproj
@@ -8,16 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Sitecore.AspNetCore.SDK.ExperienceEditor" />
+    <PackageReference Include="Sitecore.AspNetCore.SDK.LayoutService.Client" />
+    <PackageReference Include="Sitecore.AspNetCore.SDK.Pages" />
+    <PackageReference Include="Sitecore.AspNetCore.SDK.RenderingEngine" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions" />
     <Using Include="Sitecore.AspNetCore.SDK.RenderingEngine.Extensions" />
     <Using Include="Sitecore.AspNetCore.SDK.ExperienceEditor.Extensions" />
     <Using Include="Sitecore.AspNetCore.Starter.Models" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Sitecore.AspNetCore.SDK.LayoutService.Client" />
-    <PackageReference Include="Sitecore.AspNetCore.SDK.RenderingEngine" />
-    <PackageReference Include="Sitecore.AspNetCore.SDK.ExperienceEditor" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description / Motivation
Enabled Paged Metadata Editing Support as enabled in version 0.0.14 of the [ASP.NET-Core-SDK](https://github.com/Sitecore/ASP.NET-Core-SDK)
This enhancement allows users to use localhost metadata editing mode without having to use dev tunnels for local development.



## Terms
- [X] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
