### PR TITLE
Add custom hostname-based request culture provider

### DIFF
--- a/headapps/aspnet-core-starter/Extensions/HostnameRequestCultureProvider.cs
+++ b/headapps/aspnet-core-starter/Extensions/HostnameRequestCultureProvider.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Localization;
+
+namespace Sitecore.AspNetCore.Starter.Extensions
+{
+  public class HostnameRequestCultureProvider : RequestCultureProvider
+  {
+    public override Task<ProviderCultureResult?> DetermineProviderCultureResult(HttpContext httpContext)
+    {
+      ArgumentNullException.ThrowIfNull(httpContext);
+
+      // Depeneding on the hostname used, set the culture accordingly so that
+      // there is no need to use language prefix or query string parameter to switch language
+      var culture = httpContext.Request.Host.Host switch
+      {
+        "testsite.nl" => "nl-NL",
+        "testsite.de" => "de-DE",
+        _ => "en", // Default to English if no match found
+      };
+
+      return Task.FromResult<ProviderCultureResult?>(new ProviderCultureResult(culture, culture));
+
+    }
+  }
+}

--- a/headapps/aspnet-core-starter/Extensions/HostnameRequestCultureProvider.cs
+++ b/headapps/aspnet-core-starter/Extensions/HostnameRequestCultureProvider.cs
@@ -8,7 +8,7 @@ namespace Sitecore.AspNetCore.Starter.Extensions
     {
       ArgumentNullException.ThrowIfNull(httpContext);
 
-      // Depeneding on the hostname used, set the culture accordingly so that
+      // Depending on the hostname used, set the culture accordingly so that
       // there is no need to use language prefix or query string parameter to switch language
       var normalizedHost = httpContext.Request.Host.Host.ToLowerInvariant();
       var culture = normalizedHost switch

--- a/headapps/aspnet-core-starter/Extensions/HostnameRequestCultureProvider.cs
+++ b/headapps/aspnet-core-starter/Extensions/HostnameRequestCultureProvider.cs
@@ -10,7 +10,8 @@ namespace Sitecore.AspNetCore.Starter.Extensions
 
       // Depeneding on the hostname used, set the culture accordingly so that
       // there is no need to use language prefix or query string parameter to switch language
-      var culture = httpContext.Request.Host.Host switch
+      var normalizedHost = httpContext.Request.Host.Host.ToLowerInvariant();
+      var culture = normalizedHost switch
       {
         "testsite.nl" => "nl-NL",
         "testsite.de" => "de-DE",

--- a/headapps/aspnet-core-starter/Program.cs
+++ b/headapps/aspnet-core-starter/Program.cs
@@ -41,8 +41,8 @@ else
 
 builder.Services.AddSitecoreRenderingEngine(options =>
                     {
-                        options.AddStarterKitViews()
-                               .AddDefaultPartialView("_ComponentNotFound");
+                      options.AddStarterKitViews()
+                             .AddDefaultPartialView("_ComponentNotFound");                               
                     })
                 .ForwardHeaders()
                 .WithSitecorePages(sitecoreSettings.EdgeContextId ?? string.Empty, options => { options.EditingSecret = sitecoreSettings.EditingSecret; });
@@ -68,15 +68,28 @@ app.UseRouting();
 app.UseMultisite();
 app.UseStaticFiles();
 
+// example of adding several languages to be supported by the application
 const string defaultLanguage = "en";
+//const string germanLanguage = "de-DE";
+//const string dutchLanguage = "nl-NL";
 app.UseRequestLocalization(options =>
     {
-        // If you add languages in Sitecore which this site / Rendering Host should support, add them here.
         List<CultureInfo> supportedCultures = [new CultureInfo(defaultLanguage)];
+        // If you add languages in Sitecore which this site / Rendering Host should support, add them here.
+        //List<CultureInfo> supportedCultures = [new CultureInfo(defaultLanguage), new CultureInfo(germanLanguage), new CultureInfo(dutchLanguage)];
         options.DefaultRequestCulture = new RequestCulture(defaultLanguage, defaultLanguage);
         options.SupportedCultures = supportedCultures;
         options.SupportedUICultures = supportedCultures;
         options.UseSitecoreRequestLocalization();
+
+        // Custom request culture provider that should be placed after Sitecore ASP.NET SDK providers
+        // and before the provider "Microsoft.AspNetCore.Localization.AcceptLanguageHeaderRequestCultureProvider"
+      
+        // In this case app will support both setting localization by hostnam
+        // and OOTB Sitecore localization resolving by language prefix or query string parameter
+        // this might be the case when you want to have a default language set per hostname
+        // and still allow users to switch languages using language prefix or query string parameter
+        //options.RequestCultureProviders.Insert(4, new HostnameRequestCultureProvider());
     });
 
 app.MapControllerRoute(


### PR DESCRIPTION
Introduce `HostnameRequestCultureProvider` to determine culture based on the request hostname, supporting automatic culture selection. Update `Program.cs` with comments and examples for configuring multiple languages in request localization.

This is an example that highlights the case when head app serving multi-site should set default localization per site hostname. In the same time app should be able to resolve locale from URL prefix or query string parameter.

**Example**: website `testsite.nl` should set locale to nl-NL by default, however if visitor switch the language to `/en` (`testsite.nl/en/`) - language should be switched to EN.

`Program.cs` contains only commented put code, therefore default behavior of the started app shouldn't be changed.
